### PR TITLE
Add FontAwesomeIcon

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@astrojs/check": "^0.9.1",
     "@astrojs/partytown": "^2.1.2",
     "@astrojs/vue": "^4.5.0",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "astro": "^5.1.1",
     "typescript": "^5.5.4",
     "vue": "^3.4.37",

--- a/src/components/BaseMeta.astro
+++ b/src/components/BaseMeta.astro
@@ -21,10 +21,8 @@ const {
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />  <!--favicon -->
 <meta name="generator" content={Astro.generator} />
 
-
 <title>{title}</title>  <!--ページタイトル -->
 <meta name="description" content={description}/>  <!--ページ説明文 -->
-
 
 <meta property="og:site_name", content="AstroPractice">
 <meta property="og:title" content={title} />  <!--ページタイトル -->
@@ -32,7 +30,6 @@ const {
 <meta property="og:type" content={pageType}/> <!--ページのタイプ -->
 <meta property="og:image" content={image}>
 <meta property="og:image:alt" content={imageAlt}>
-
 
 <meta name="twitter:card" content="summary_large_image">  <!--Twitterカードの種類 -->
 <meta name="twitter:title" content={title}>  <!--ページタイトル -->

--- a/src/components/atoms/FontAwesomeIcon.astro
+++ b/src/components/atoms/FontAwesomeIcon.astro
@@ -1,0 +1,14 @@
+---
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+import { icon, type IconLookup, type IconName, type IconParams } from '@fortawesome/fontawesome-svg-core'
+
+interface Props {
+  icon: IconName | IconLookup
+  params?: IconParams
+}
+
+const { html } = icon(Astro.props.icon, Astro.props.params)
+---
+
+<Fragment set:html={html} />

--- a/src/components/atoms/HambMenu.vue
+++ b/src/components/atoms/HambMenu.vue
@@ -33,24 +33,6 @@ const closeMenu = () => {
   emit('closeMenu');
 }
 </script>
-<!--
-<script>
-export default {
-  data() {
-    return {
-      hambflag: false,
-      scrollableflag: false,
-    }
-  },
-  methods: {
-    closeMenu() {
-      this.$emit('closeMenu')
-      this.toggleScroll(true)
-    },
-  }
-}
-</script>
--->
 <style lang='scss' scoped>
 .hamb{
   &__nav{

--- a/src/components/organisms/header.astro
+++ b/src/components/organisms/header.astro
@@ -1,7 +1,6 @@
 ---
 import Hamb from "../molecules/hamb.vue";
 ---
-
 <header>
     <nav>
         <ul class="nav__menu">
@@ -29,7 +28,6 @@ import Hamb from "../molecules/hamb.vue";
     </nav>
     <Hamb client:load />
 </header>
-
 <style lang="scss" scoped>
 .nav{
     &__menu{
@@ -43,7 +41,6 @@ import Hamb from "../molecules/hamb.vue";
         width: 1280px;
     }
 }
-
 header{
     position: sticky;
     display: flex;

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -13,6 +13,7 @@ import BaseMeta from '../components/BaseMeta.astro';
 import Header from '../components/organisms/header.astro';
 import "../styles/reset.scss";
 import "../styles/markdown.scss"
+import '@fortawesome/fontawesome-svg-core/styles.css'
 ---
 
 <!Doctype html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,6 +13,7 @@ import Container from '../components/atoms/Container.astro';
 import BaseMeta from '../components/BaseMeta.astro';
 import Header from '../components/organisms/header.astro';
 import "../styles/reset.scss";
+import '@fortawesome/fontawesome-svg-core/styles.css'
 ---
 
 <!Doctype html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,6 +17,5 @@ const head: Props = {
   imageAlt: "Sample Image Alt Text"
 };
 ---
-
 <Layout {...head}>
 </Layout>

--- a/src/pages/news/[id].astro
+++ b/src/pages/news/[id].astro
@@ -37,7 +37,6 @@ const { Content } = await render(post);
     <Content />
     
 </ContentLayout>
-
 <style lang="scss" scoped>
 h1{
   font-size: 32px;

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -48,12 +48,10 @@ const head: Props = {
     )}
   </ul>
 </Layout>
-
 <style lang="scss" scoped>
 h1 {
   margin-bottom: 1rem;
 }
-
 .news {
   &__contents {
     margin: 1rem;

--- a/src/pages/practice.astro
+++ b/src/pages/practice.astro
@@ -1,8 +1,8 @@
 ---
+import FontAwesomeIcon from "../components/atoms/FontAwesomeIcon.astro";
+import { faAngleRight, faHouse} from "@fortawesome/free-solid-svg-icons";
 import Layout from "../layouts/Layout.astro";
-
 ---
-
 <Layout 
 	title= "Sample Title",
 	description="Sample Description",
@@ -13,4 +13,14 @@ import Layout from "../layouts/Layout.astro";
 	<h1>
 		Hello World
 	</h1>
+	<span class="icon">
+		<FontAwesomeIcon icon={faAngleRight} />
+	</span>
+	<FontAwesomeIcon icon={faHouse} />
 </Layout>
+<style lang="scss" scoped>
+.icon{
+	color: red;
+	font-size: 64px;
+}
+</style>

--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -11,7 +11,6 @@ h2{
     border-left: solid 6px #c71111;
     margin-bottom: 12px;
 }
-
 h3{
     margin-top: 1rem;
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,0 +1,6 @@
+body{
+    font-size: 16px;
+    color: $black;
+    background-color: #f9f8ff;
+    font-family: 'sans-serif';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,25 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz#168ab1c7e1c318b922637fad8f339d48b01e1244"
   integrity sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==
 
+"@fortawesome/fontawesome-common-types@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz#7123d74b0c1e726794aed1184795dbce12186470"
+  integrity sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==
+
+"@fortawesome/fontawesome-svg-core@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz#0ac6013724d5cc327c1eb81335b91300a4fce2f2"
+  integrity sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.7.2"
+
+"@fortawesome/free-solid-svg-icons@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz#fe25883b5eb8464a82918599950d283c465b57f6"
+  integrity sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.7.2"
+
 "@img/sharp-darwin-arm64@0.33.4":
   version "0.33.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz#a1cf4a7febece334f16e0328b9689f05797d7aec"


### PR DESCRIPTION
# FontAwesomeIconの導入
[このサイト](https://www.inkohx.dev/articles/use-fontawesome-with-astro/)を参考に導入

# 注意
- `FontAwesomeIcon`コンポーネントにクラスを付与することはできないため、`<span>`で囲み、`<span>`に対して付与することでCSSを適用させる。
- 各ページでアイコンをインポートする必要あり
- `import '@fortawesome/fontawesome-svg-core/styles.css';`は共通レイアウトに必ず記述する